### PR TITLE
Wip/create missing ports on start

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,2 @@
+Jason Anderson <jasonanderson@uchicago.edu>
 Michael Sherman <shermanm@uchicago.edu>
-Mike <msherman64@gmail.com>
-Mike <shermanm@uchicago.edu>

--- a/networking_wireguard/ml2/agent/wg.py
+++ b/networking_wireguard/ml2/agent/wg.py
@@ -40,6 +40,25 @@ def get_all_devices():
     return devices
 
 
+def _create_wg_link(device_name):
+
+    ip_dev = ip_lib.IPWrapper().device(device_name)
+    ip_dev.kind = IP_LINK_KIND
+    try:
+        ip_dev.link.create()
+    except privileged.InterfaceAlreadyExists:
+        pass
+    return ip_dev
+
+
+def _move_wg_netns(ip_link_device, netns_name):
+    # Move iface from root namespace to project namespace
+    ip_dev = ip_link_device
+    netns = ip_lib.IPWrapper().ensure_namespace(netns_name)
+    ip_dev.link.set_netns(netns.namespace)
+    return ip_dev, netns
+
+
 def create_device_from_port(port):
     """Create wireguard interface and move to netns.
 
@@ -47,17 +66,10 @@ def create_device_from_port(port):
     then moves it to the target namespace. This ensures that
     the "outside" of the tunnel can access network resources.
     """
-    device = get_device_name(port["id"])
-    ip_dev = ip_lib.IPWrapper().device(device)
-    ip_dev.kind = IP_LINK_KIND
-    try:
-        ip_dev.link.create()
-    except privileged.InterfaceAlreadyExists:
-        pass
-
-    # Move iface from root namespace to project namespace
-    netns = ip_lib.IPWrapper().ensure_namespace(_get_netns_name(port))
-    ip_dev.link.set_netns(netns.namespace)
+    device_name = get_device_name(port["id"])
+    netns_name = _get_netns_name(port)
+    ip_dev = _create_wg_link(device_name)
+    ip_dev, netns = _move_wg_netns(ip_dev, netns_name)
 
     listen_port = utils.find_free_port()
     privkey = utils.gen_privkey()
@@ -72,7 +84,7 @@ def create_device_from_port(port):
                 [
                     "wg",
                     "set",
-                    device,
+                    device_name,
                     "listen-port",
                     listen_port,
                     "private-key",
@@ -82,7 +94,7 @@ def create_device_from_port(port):
                 # privsep_exec=True,
             )
 
-        with open(_device_config_file(device), "w") as file:
+        with open(_device_config_file(device_name), "w") as file:
             file.write(
                 netns.netns.execute(
                     ["wg", "showconf", device],
@@ -90,7 +102,7 @@ def create_device_from_port(port):
                     # privsep_exec=True,
                 )
             )
-            LOG.info(f"Wrote configuration for {device} to {file.name}")
+            LOG.info(f"Wrote configuration for {device_name} to {file.name}")
 
     except IOError:
         LOG.warn("Failed to bind port")

--- a/networking_wireguard/ml2/agent/wg.py
+++ b/networking_wireguard/ml2/agent/wg.py
@@ -106,6 +106,7 @@ def sync_device(device, peers=None):
     try:
         wc.read_file()
     except FileNotFoundError:
+        LOG.warn(f"Config file not found for wg device {device}")
         return
     new_peers = {
         peer["public_key"]: ",".join(peer["allowed_ips"]) for peer in peers
@@ -161,6 +162,7 @@ def _get_device_netns(device):
 def plug_device(device, addresses=[], flush_addresses=False):
     ns = _get_device_netns(device)
     if not ns:
+        LOG.warn(f"Device not found: {device}")
         return False
     try:
         ns_dev = ns.device(device)

--- a/networking_wireguard/ml2/agent/wg_agent.py
+++ b/networking_wireguard/ml2/agent/wg_agent.py
@@ -479,7 +479,12 @@ class WireguardAgentCallbacks(object):
         return updated_devices
 
     def get_subnet_details(self, subnet_id):
-        return self.cached_subnets.get(subnet_id)
+        subnet_details = self.cached_subnets.get(subnet_id)
+        if not subnet_details:
+            # add to cache if we don't have it
+            subnet_details = self.driver_rpc.get_subnet(subnet_id)
+            self.cached_subnets[subnet_id] = subnet_details
+        return subnet_details
 
     def port_update(self, context, **kwargs):
         port = kwargs.get("port")

--- a/networking_wireguard/ml2/agent/wg_agent.py
+++ b/networking_wireguard/ml2/agent/wg_agent.py
@@ -382,6 +382,7 @@ class WireguardAgent(service.Service):
             device_info["added"] = current_devices - previous["current"]
             device_info["removed"] = previous["current"] - current_devices
             device_info["updated"] = updated_devices & current_devices
+            device_info["missing"] = previous["missing"]
 
         return device_info
 


### PR DESCRIPTION
this PR attempts to recreate a hub port if neutron thinks it should exist, but doesn't.

It does depend on the interface config file still existing in the container/volume, although all information aside from the private key exists in neutron's binding profile.

Lots of edge cases, and the control flow is very messy, but works for now!
It successfully recovers if you delete the interface while the agent is running, and puts it back.

