### PR TITLE
wg hub is now scoped using a conf option

### DIFF
--- a/networking_wireguard/ml2/agent/wg_agent.py
+++ b/networking_wireguard/ml2/agent/wg_agent.py
@@ -269,8 +269,8 @@ class WireguardAgent(service.Service):
         # 1. Ensure the Wireguard interface exists and has a port/privkey assigned.
         listen_port, public_key = wg.ensure_device(
             device,
-            # Only scope the device to a project if it was not requested as a root dev
-            project_id=(not hub_config.root_device and hub_config.project_id),
+            # Only scope the device to a project based on a configuration option
+            project_id= not CONF.wireguard.create_hub_in_root_netns,
             dry_run=dry_run,
         )
         if public_key:
@@ -523,6 +523,10 @@ def main():
                 "debugging of changes."
             ),
         ),
+        cfg.BoolOpt(
+            "create_hub_in_root_netns",
+            default=True,
+            help="Create wireguard hub in root network namespace"),
     ]
     cfg.CONF.register_opts(wireguard_opts, "wireguard")
 


### PR DESCRIPTION
The previous approach to deciding whether to scope the wireguard hub port to a project network namespace or the root network namespace relied on a complicated boolean expression that was evaluated using options from the neutron database, overall, creating too many scenarios in which the scoping did not behave correctly. This change is meant to replace the complex and esoteric expression with a simple configuration option that decides the scoping. By default the wg hub port created by the admin project in an effort to spin up a hub and spoke platform should be scoped to the root network namespace.

This change however remains a temporary solution to a broader problem in which hub ports should be automatically scoped depending on the project by which they are created.